### PR TITLE
PR Checks / Clippy: check all targets

### DIFF
--- a/.github/workflows/pr-checks.yaml
+++ b/.github/workflows/pr-checks.yaml
@@ -41,7 +41,7 @@ jobs:
       - uses: actions-rs/clippy-check@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          args: --all-features
+          args: --all-features --all-targets
 
   msrv:
     name: cargo msrv


### PR DESCRIPTION
Run Clippy on all targets, e.g. tests, not just the main library or executable.