### PR TITLE
Release 0.1.2: upgrade git2 for security

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,17 @@
 
 All notable changes to this project will be documented in this file.
 
-## main branch
+## Release 0.1.2 (2023-06-21)
+
+### Security fixes
+
+* Upgrade [git2] dependency to 0.17.2 to fix a [security vulnerability in its
+  handling of SSH keys][GHSA-m4ch-rfv5-x5g3]. This was unlikely to affect
+  iai-parse since it doesn’t fetch data from, or otherwise interact with, remote
+  repositories.
+
+[git2]: https://crates.io/crates/git2
+[GHSA-m4ch-rfv5-x5g3]: https://github.com/rust-lang/git2-rs/security/advisories/GHSA-m4ch-rfv5-x5g3
 
 ## Release 0.1.1 (2023-01-19)
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -154,9 +154,9 @@ dependencies = [
 
 [[package]]
 name = "git2"
-version = "0.16.0"
+version = "0.17.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be36bc9e0546df253c0cc41fd0af34f5e92845ad8509462ec76672fac6997f5b"
+checksum = "7b989d6a7ca95a362cf2cfc5ad688b3a467be1f87e480b8dad07fee8c79b0044"
 dependencies = [
  "bitflags",
  "libc",
@@ -188,7 +188,7 @@ dependencies = [
 
 [[package]]
 name = "iai-parse"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "anyhow",
  "clap",
@@ -269,9 +269,9 @@ checksum = "201de327520df007757c1f0adce6e827fe8562fbc28bfd9c15571c66ca1f5f79"
 
 [[package]]
 name = "libgit2-sys"
-version = "0.14.1+1.5.0"
+version = "0.15.2+1.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a07fb2692bc3593bda59de45a502bb3071659f2c515e28c71e728306b038e17"
+checksum = "a80df2e11fb4a61f4ba2ab42dbe7f74468da143f1a75c74e11dee7c813f694fa"
 dependencies = [
  "cc",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "iai-parse"
-version = "0.1.1"
+version = "0.1.2"
 authors = ["Daniel Parks <oss-iai-parse@demonhorse.org>"]
 description = "Convert iai benchmark output to CSV."
 homepage = "https://github.com/danielparks/iai-parse"
@@ -17,7 +17,7 @@ rust-version = "1.64"
 anyhow = "1.0.44"
 clap = { version = "4.0.18", features = ["derive"] }
 csv = "1.1.6"
-git2 = { version = "0.16.0", default-features = false }
+git2 = { version = "0.17.2", default-features = false }
 indexmap = "1.9.2"
 
 [dev-dependencies]


### PR DESCRIPTION
This upgrades the [git2] dependency to 0.17.2 to fix a [security vulnerability in its handling of SSH keys][GHSA-m4ch-rfv5-x5g3]. This was unlikely to affect iai-parse since it doesn’t fetch data from, or otherwise interact with, remote repositories.

This vulnerability was discovered months ago, but somehow I missed that iai-parse could be affected. I actually updated [git-status-vars] in January to fix it (though it was likely not vulnerable either).

[git2]: https://crates.io/crates/git2
[GHSA-m4ch-rfv5-x5g3]: https://github.com/rust-lang/git2-rs/security/advisories/GHSA-m4ch-rfv5-x5g3
[git-status-vars]: https://github.com/danielparks/git-status-vars