### PR TITLE
Use cargo-lints to centrally configure lints

### DIFF
--- a/.github/workflows/pr-checks.yaml
+++ b/.github/workflows/pr-checks.yaml
@@ -38,10 +38,10 @@ jobs:
       - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           components: clippy
-      - uses: actions-rs/clippy-check@v1
+      - uses: taiki-e/install-action@v2
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          args: --all-features --all-targets
+          tool: cargo-lints
+      - run: cargo lints clippy --all-features --all-targets
 
   deny:
     name: cargo deny

--- a/lints.toml
+++ b/lints.toml
@@ -1,0 +1,54 @@
+deny = [
+  "unsafe_code",
+]
+
+warn = [
+  "clippy::nursery",
+  "clippy::pedantic",
+
+  # Require docs
+  "missing_docs",
+  "clippy::missing_docs_in_private_items",
+
+  # Other restriction lints
+  "clippy::arithmetic_side_effects",
+  "clippy::as_underscore",
+  "clippy::assertions_on_result_states",
+  "clippy::dbg_macro",
+  "clippy::default_union_representation",
+  "clippy::empty_structs_with_brackets",
+  "clippy::filetype_is_file", # maybe?
+  "clippy::fn_to_numeric_cast_any",
+  "clippy::format_push_string", # maybe? alternative is fallible.
+  "clippy::get_unwrap",
+  "clippy::impl_trait_in_params",
+  "clippy::integer_division",
+  "clippy::lossy_float_literal",
+  "clippy::mem_forget",
+  "clippy::mixed_read_write_in_expression",
+  "clippy::multiple_inherent_impl",
+  "clippy::multiple_unsafe_ops_per_block",
+  "clippy::mutex_atomic",
+  "clippy::rc_buffer",
+  "clippy::rc_mutex",
+  "clippy::same_name_method",
+  "clippy::semicolon_inside_block",
+  "clippy::str_to_string",
+  "clippy::string_to_string",
+  "clippy::undocumented_unsafe_blocks",
+  "clippy::unnecessary_safety_doc",
+  "clippy::unnecessary_self_imports",
+  "clippy::unneeded_field_pattern",
+  "clippy::verbose_file_reads",
+]
+
+allow = [
+  # Pedantic exceptions
+  "clippy::let_underscore_untyped",
+  "clippy::manual_string_new",
+  "clippy::map_unwrap_or",
+  "clippy::module_name_repetitions",
+
+  # Nursery exceptions
+  "clippy::option_if_let_else",
+]

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,7 @@
+//! iai-parse executable.
+
+// Most lint configuration is in lints.toml, but it doesn’t support forbid.
 #![forbid(unsafe_code)]
-#![warn(clippy::pedantic)]
-#![allow(clippy::let_underscore_untyped, clippy::map_unwrap_or)]
 
 use anyhow::Context;
 use clap::Parser;
@@ -14,6 +15,7 @@ use std::path::{Path, PathBuf};
 use std::process::exit;
 use std::result::Result;
 
+/// Parameters to configure executable.
 #[derive(Debug, clap::Parser)]
 #[clap(version, about)]
 struct Params {
@@ -30,31 +32,51 @@ struct Params {
     git_repo: Option<PathBuf>,
 }
 
+/// A table of [`Column`]s that can be written to CSV.
+///
+/// Each column represent a benchmark run.
 #[derive(Clone, Debug, Default)]
 struct Table {
+    /// An ordered map of column names to [`Column`]s.
     columns: IndexMap<Vec<u8>, Column>,
 }
 
+/// A column of values from a benchmark run.
 #[derive(Clone, Debug, Default)]
 struct Column {
+    /// Ordered map of individual benchmark names (e.g. a function name) to
+    /// ordered map of benchmark parameter names to values, e.g.
+    /// `b"Instructions" : b"451"`.
     benchmarks: IndexMap<Vec<u8>, IndexMap<Vec<u8>, Vec<u8>>>,
 }
 
 impl Table {
+    /// Get a [`Column`] by `name`.
+    ///
+    /// This will create a column if it doesn’t already exist.
     pub fn column(&mut self, name: &[u8]) -> &mut Column {
         self.columns
             .entry(name.to_vec())
             .or_insert_with(Column::default)
     }
 
+    /// Get a vector of byte strings representing headers in the table.
+    ///
+    /// The first two will always be `b"benchmark"` and `b"parameter"`; the
+    /// following entries will the names of the columns.
     pub fn headers(&self) -> Vec<Vec<u8>> {
-        let mut headers = Vec::with_capacity(2 + self.columns.len());
+        let mut headers = Vec::with_capacity(
+            // Very unlikely to fail.
+            self.columns.len().checked_add(2).unwrap(),
+        );
         headers.push(b"benchmark".to_vec());
         headers.push(b"parameter".to_vec());
         headers.extend(self.columns.keys().cloned());
         headers
     }
 
+    /// Return all unique pairs of individual benchmark names (e.g. function
+    /// names) and parameter names (e.g. “Instructions”).
     pub fn benchmarks_and_parameters(&self) -> IndexSet<(Vec<u8>, Vec<u8>)> {
         self.columns
             .values()
@@ -70,6 +92,11 @@ impl Table {
             .collect()
     }
 
+    /// Write table contents as CSV.
+    ///
+    /// # Errors
+    ///
+    /// Returns IO errors from trying to write data.
     pub fn write_csv<W: io::Write>(&self, writer: W) -> anyhow::Result<()> {
         let mut csv_writer = csv::Writer::from_writer(writer);
         csv_writer.write_record(self.headers())?;
@@ -88,6 +115,7 @@ impl Table {
 }
 
 impl Column {
+    /// Get a parameter value from an individual benchmark within this run.
     pub fn get(
         &self,
         benchmark: &Vec<u8>,
@@ -98,6 +126,7 @@ impl Column {
             .and_then(|parameter_map| parameter_map.get(parameter))
     }
 
+    /// Set a parameter value for an individual benchmark within this run.
     pub fn set(&mut self, benchmark: &[u8], parameter: &[u8], value: &[u8]) {
         let parameter_map = self
             .benchmarks
@@ -107,7 +136,10 @@ impl Column {
         parameter_map.insert(parameter.to_vec(), value.to_vec());
     }
 
-    pub fn benchmarks(&self) -> &IndexMap<Vec<u8>, IndexMap<Vec<u8>, Vec<u8>>> {
+    /// Get the ordered map of benchmark names to parameter maps.
+    pub const fn benchmarks(
+        &self,
+    ) -> &IndexMap<Vec<u8>, IndexMap<Vec<u8>, Vec<u8>>> {
         &self.benchmarks
     }
 }
@@ -119,6 +151,11 @@ fn main() {
     }
 }
 
+/// Do real work and return errors so that they can be reported nicely.
+///
+/// # Errors
+///
+/// This returns various errors that should be reported to the user.
 fn cli(params: Params) -> anyhow::Result<()> {
     if params.git_revs.is_empty() {
         return parse_in_working_tree(params);
@@ -189,6 +226,7 @@ fn cli(params: Params) -> anyhow::Result<()> {
     Ok(())
 }
 
+/// Parse paths from the filesystem (as opposed to from git history).
 fn parse_in_working_tree(params: Params) -> anyhow::Result<()> {
     let mut table = Table::default();
     {
@@ -203,6 +241,7 @@ fn parse_in_working_tree(params: Params) -> anyhow::Result<()> {
     Ok(())
 }
 
+/// Abbreviate a git hash to 7 characters.
 // FIXME: should we be checking that the abbreviations are unique?
 fn abbrev(oid: git2::Oid) -> String {
     let mut hash = oid.to_string();
@@ -210,6 +249,14 @@ fn abbrev(oid: git2::Oid) -> String {
     hash
 }
 
+/// Generate an iterator of commits from a git repo and revspec.
+///
+/// The iterator will be in order from oldest to newest.
+///
+/// # Errors
+///
+/// Returns an error if revspec couldn’t be parsed, or the commits couldn’t be
+/// found in the repository.
 fn revspec_parse<'r>(
     repo: &'r Repository,
     revspec_str: &str,
@@ -265,11 +312,18 @@ fn revspec_parse<'r>(
     }
 }
 
+/// Read the passed `path` to a byte string.
+///
+/// # Errors
+///
+/// Returns an error if the file couldn’t be read. The error message will start
+/// with “Failed to read path/to/file”.
 fn read<P: AsRef<Path>>(path: P) -> anyhow::Result<Vec<u8>> {
     let path = path.as_ref();
     fs::read(path).with_context(|| format!("Failed to read {}", path.display()))
 }
 
+/// Parse a byte string and write it to the passed [`Column`].
 fn parse<B>(input: B, column: &mut Column)
 where
     B: AsRef<[u8]>,
@@ -298,6 +352,7 @@ where
     }
 }
 
+/// Find the subslice with leading spaces removed.
 fn trim_leading_spaces(input: &[u8]) -> &[u8] {
     if let Some(start) = input.iter().position(|&c| c != b' ') {
         &input[start..]
@@ -306,12 +361,15 @@ fn trim_leading_spaces(input: &[u8]) -> &[u8] {
     }
 }
 
+/// Find the first sequence of non-space characters as a subslice.
 fn parse_parameter_value(input: &[u8]) -> &[u8] {
     let mut iter = input.iter();
     let start = iter
         .position(|&c| c != b' ')
         .expect("parameter value empty");
     if let Some(end) = iter.position(|&c| c == b' ') {
+        // start + end must be a valid index within input.
+        #[allow(clippy::arithmetic_side_effects)]
         &input[start..=start + end]
     } else {
         &input[start..]


### PR DESCRIPTION
Previously lints had to be configured at the top of every entry point in rust code. This allows lints to be centrally configured in `lints.toml` and ensures they are applied to all targets.

This also updates the lint list to match my other projects. It includes a bunch more restriction lints.

To run lints:

    cargo lints clippy --all-targets --all-features

This requires [cargo-lints] to be installed.

[cargo-lints]: https://crates.io/crates/cargo-lints