### PR TITLE
Enable `clippy::option_if_let_else`

### DIFF
--- a/lints.toml
+++ b/lints.toml
@@ -48,7 +48,4 @@ allow = [
   "clippy::manual_string_new",
   "clippy::map_unwrap_or",
   "clippy::module_name_repetitions",
-
-  # Nursery exceptions
-  "clippy::option_if_let_else",
 ]

--- a/src/main.rs
+++ b/src/main.rs
@@ -354,6 +354,9 @@ where
 
 /// Find the subslice with leading spaces removed.
 fn trim_leading_spaces(input: &[u8]) -> &[u8] {
+    // This could use `map()`, but it’s not a natural usage since it doesn’t
+    // transform `start`, it uses `start` to transform `input`.
+    #[allow(clippy::option_if_let_else)]
     if let Some(start) = input.iter().position(|&c| c != b' ') {
         &input[start..]
     } else {
@@ -367,6 +370,10 @@ fn parse_parameter_value(input: &[u8]) -> &[u8] {
     let start = iter
         .position(|&c| c != b' ')
         .expect("parameter value empty");
+
+    // This could use `map()`, but it’s not a natural usage since it doesn’t
+    // transform `end`, it uses `end` to transform `input`.
+    #[allow(clippy::option_if_let_else)]
     if let Some(end) = iter.position(|&c| c == b' ') {
         // start + end must be a valid index within input.
         #[allow(clippy::arithmetic_side_effects)]


### PR DESCRIPTION
My other projects have this lint enabled, but it flags inappropriate checks in this crate. This switches to enabling it overall and disabling it in the specific places where it’s suggestions are bad.