### PR TITLE
Release 0.1.3: update dependencies for security

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 
-## main branch
+## Release 0.1.3 (2024-02-12)
 
 ### Security fixes
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -183,7 +183,7 @@ dependencies = [
 
 [[package]]
 name = "iai-parse"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "iai-parse"
-version = "0.1.2"
+version = "0.1.3"
 authors = ["Daniel Parks <oss-iai-parse@demonhorse.org>"]
 description = "Convert iai benchmark output to CSV."
 homepage = "https://github.com/danielparks/iai-parse"


### PR DESCRIPTION
There were a few security vulnerabilities in libgit2 and rustix that probably did not affect iai-parse. See CHANGELOG.md for details.