### PR TITLE
Fix lint priority

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,8 +31,8 @@ unsafe_code = "forbid"
 missing_docs = "warn"
 
 [workspace.lints.clippy]
-nursery = "warn"
-pedantic = "warn"
+nursery = { level = "warn", priority = -1 }
+pedantic = { level = "warn", priority = -1 }
 missing_docs_in_private_items = "warn"
 
 # Other restriction lints
@@ -71,3 +71,6 @@ let_underscore_untyped = "allow"
 manual_string_new = "allow"
 map_unwrap_or = "allow"
 module_name_repetitions = "allow"
+
+# Nursery exceptions
+option_if_let_else = "allow"


### PR DESCRIPTION
Lint rules in the `[lints]` table are not applied in file order. This could cause certain rules to be ignored if they were applied before the rule that effects the group they were in. For example, if `clippy::nursery` and `clippy::option_if_let_else` have the same priority, then `nursery` gets applied after `option_if_let_else`, causing the more specific rule to be ignored.

This explicitly sets `nursery` and `pedantic` to priority -1 so that they are overridden by more specific rules (which are priority 0 by default).