### PR TITLE
Release 0.1.7-alpha1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## main branch
 
+* More improvements to release process; no functional changes.
+
 ## Release 0.1.6 (2025-10-21)
 
 * Improvements to release process; no functional changes.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 
-## main branch
+## Release 0.1.7-alpha1 (2025-10-22)
 
 * More improvements to release process; no functional changes.
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -201,7 +201,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "iai-parse"
-version = "0.1.6"
+version = "0.1.7-alpha1"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "iai-parse"
-version = "0.1.6"
+version = "0.1.7-alpha1"
 authors = ["Daniel Parks <oss-iai-parse@demonhorse.org>"]
 description = "Convert iai benchmark output to CSV."
 homepage = "https://github.com/danielparks/iai-parse"

--- a/release.sh
+++ b/release.sh
@@ -77,20 +77,20 @@ case "$branch_name" in
   *) echo "Not on main or release branch" >&2 ; exit 1 ;;
 esac
 
-if !command -v gh &>/dev/null ; then
+command -v gh &>/dev/null || {
   echo "gh not installed (https://cli.github.com)" >&2
   exit 1
-fi
+}
 
-if !command -v jq &>/dev/null ; then
+command -v jq &>/dev/null || {
   echo "jq not installed (https://jqlang.org)" >&2
   exit 1
-fi
+}
 
-if !command -v parse-changelog &>/dev/null ; then
+command -v parse-changelog &>/dev/null || {
   echo "parse-changelog not installed (https://github.com/taiki-e/parse-changelog)" >&2
   exit 1
-fi
+}
 
 check-changes
 

--- a/release.sh
+++ b/release.sh
@@ -124,14 +124,15 @@ cat "$changelog"
 echo
 confirm 'Release notes displayed above. Continue?'
 
-if !check-changes &>/dev/null ; then
+# Commit version bump if necessary.
+check-changes &>/dev/null || {
   git add -u
   git commit --cleanup=verbatim --file - <<EOF
 Release ${version}
 
 $(parse-changelog CHANGELOG.md "$version")
 EOF
-fi
+}
 
 check-changes
 

--- a/release.sh
+++ b/release.sh
@@ -32,7 +32,7 @@ check-changes () {
 }
 
 auto-pr () {
-  pr_url=$(gh pr view --json url,closed 2>/dev/null \
+  pr_url=$(gh pr view --json url,closed 2>/dev/null || true \
     | jq -r 'select(.closed | not) | .url')
 
   if [[ "$pr_url" ]] ; then

--- a/release.sh
+++ b/release.sh
@@ -71,12 +71,6 @@ case $version in
   *) echo "Usage $0 VERSION" >&2 ; exit 1 ;;
 esac
 
-case "$branch_name" in
-  release*) ;; # Good
-  main) git switch -c "release-$version" ;;
-  *) echo "Not on main or release branch" >&2 ; exit 1 ;;
-esac
-
 command -v gh &>/dev/null || {
   echo "gh not installed (https://cli.github.com)" >&2
   exit 1
@@ -91,6 +85,10 @@ command -v parse-changelog &>/dev/null || {
   echo "parse-changelog not installed (https://github.com/taiki-e/parse-changelog)" >&2
   exit 1
 }
+
+if [[ "$branch_name" = main ]] ; then
+  git switch -c "release-$version"
+fi
 
 check-changes
 

--- a/release.sh
+++ b/release.sh
@@ -67,7 +67,7 @@ confirm () {
 }
 
 case $version in
-  +([0-9]).+([0-9]).+([0-9])) ;; # Good
+  +([0-9]).+([0-9]).+([0-9])*) ;; # Good
   *) echo "Usage $0 VERSION" >&2 ; exit 1 ;;
 esac
 

--- a/release.sh
+++ b/release.sh
@@ -138,7 +138,7 @@ git tag --sign --file "$changelog" --cleanup=verbatim "v${version}"
 git push --tags origin HEAD
 auto-pr "Release ${version}"
 
-cargo publish
+#cargo publish
 
 awk-in-place CHANGELOG.md '
   /^## Release/ && !done {


### PR DESCRIPTION
- **`release.sh`: remove dependencies on my `git` aliases.**
  

- **`release.sh`: Allow alpha releases.**
  

- **`release.sh`: correctly commit version bump.**
  

- **`release.sh`: fix `if !` tests.**
  

- **`release.sh`: don’t require branch name to be release*.**
  

- **`release.sh`: don’t fail if PR doesn’t exist.**
  

- **`release.sh`: Disable `cargo publish` for testing.**
  

- **Release 0.1.7-alpha1**
  * More improvements to release process; no functional changes.
  