### PR TITLE
Clean up fake test release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 All notable changes to this project will be documented in this file.
 
+## main branch
+
 ## Release 0.1.7-alpha1 (2025-10-22)
 
 * More improvements to release process; no functional changes.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,6 @@ All notable changes to this project will be documented in this file.
 
 ## main branch
 
-## Release 0.1.7-alpha1 (2025-10-22)
-
-* More improvements to release process; no functional changes.
-
 ## Release 0.1.6 (2025-10-21)
 
 * Improvements to release process; no functional changes.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -201,7 +201,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "iai-parse"
-version = "0.1.7-alpha1"
+version = "0.1.6"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "iai-parse"
-version = "0.1.7-alpha1"
+version = "0.1.6"
 authors = ["Daniel Parks <oss-iai-parse@demonhorse.org>"]
 description = "Convert iai benchmark output to CSV."
 homepage = "https://github.com/danielparks/iai-parse"

--- a/release.sh
+++ b/release.sh
@@ -154,5 +154,5 @@ git diff --staged
 confirm 'Commit with message "Prepping CHANGELOG.md for development."?'
 
 git commit -m 'Prepping CHANGELOG.md for development.'
-git push origin HEAD
+git push --force origin HEAD
 auto-pr "Prepping CHANGELOG.md for development"

--- a/release.sh
+++ b/release.sh
@@ -138,7 +138,7 @@ git tag --force --sign --file "$changelog" --cleanup=verbatim "v${version}"
 git push --force --tags origin HEAD
 auto-pr "Release ${version}"
 
-#cargo publish
+cargo publish
 
 awk-in-place CHANGELOG.md '
   /^## Release/ && !done {


### PR DESCRIPTION
- **Prepping CHANGELOG.md for development.**
  

- **`release.sh`: force push clean up branch.**
  

- **Remove references to fake test release 0.1.7-alpha1.**
  

- **`release.sh`: re-enable `cargo publish`.**
  